### PR TITLE
Harden check-deps command execution

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +14,16 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error("Error: Invalid dependency name.");
+	process.exit(1);
+}
+
+process.chdir(join("packages", dep));
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], { encoding: "utf-8" }).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +32,41 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+const localTarball = execFileSync("npm", ["pack"], { encoding: "utf-8" }).trim();
+renameSync(localTarball, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+const remoteTarball = execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`], { encoding: "utf-8" }).trim();
+renameSync(remoteTarball, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+mkdirSync("local", { recursive: true });
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("remote", { recursive: true });
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
+	execFileSync("diff", ["--brief", "-r", "local", "remote"]);
 } catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	const output = (e as { output?: Array<string | Buffer | null> }).output;
+	if (output) {
+		console.error(
+			output
+				.filter((entry): entry is string | Buffer => Boolean(entry))
+				.map((entry) => entry.toString())
+				.join("\n")
+		);
+	}
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"860298cb-e58b-4181-ac31-efce2c388ddb","source":"chat","resourceId":"76e93293-b335-4d2e-b03d-bcc43336274f","workflowId":"d6f75683-d455-4533-ba66-d10a94aa94e3","codeChangeId":"d6f75683-d455-4533-ba66-d10a94aa94e3","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/4be4e603aac06599b9b8f613786fdaf1?panel_event_id=AwAAAZ8iVPFzq0dwaAAAABhBWjhpVlBGekFBQlB3SWZWdmpoMjFzZnoAAAAkZjE5ZjIyNjAtZDgxZi00ZmE3LWExNTUtYjhkZWUzOWM0MTQ4AAAvqg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NGJlNGU2MDNhYWMwNjU5OWI5YjhmNjEzNzg2ZmRhZjF-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Hardened the dependency consistency check script to eliminate shell-invocation injection risk from untrusted dependency input while keeping existing behavior for package comparison.

## Changes
- Replaced shell-string `execSync(...)` usage with argument-safe `execFileSync(...)` calls.
- Added strict dependency name validation (`^[a-z0-9-]+$`) before using the positional argument.
- Replaced shell file operations (`mv`, `rm`, `mkdir`) with Node filesystem APIs (`renameSync`, `rmSync`, `mkdirSync`).
- Kept tar extraction and diff behavior but executed with explicit argv arrays instead of shell commands.

## Testing
- Attempted targeted checks:
  - `pnpm exec prettier --check scripts/check-deps.ts`
  - `pnpm exec eslint scripts/check-deps.ts`
- Both commands could not run in this sandbox because Corepack attempted to download pnpm from the internet, which is blocked in this environment.
- Performed manual diff review to confirm the vulnerable shell interpolation path was removed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/76e93293-b335-4d2e-b03d-bcc43336274f)

Comment @datadog to request changes