### PR TITLE
Harden check-deps against command injection

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,5 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +13,19 @@ if (!dep) {
 	process.exit(1);
 }
 
+if (!/^[a-z0-9-]+$/i.test(dep)) {
+	console.error("Error: Invalid dependency name.");
+	process.exit(1);
+}
+
+const runCommand = (command: string, args: string[]): string =>
+	execFileSync(command, args, { encoding: "utf-8" }).trim();
+
 process.chdir(`./packages/${dep}`);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = runCommand("npm", ["view", `@huggingface/${dep}`, "version"]);
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +34,42 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+runCommand("npm", ["pack"]);
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+runCommand("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`]);
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+mkdirSync("local");
+runCommand("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("remote");
+runCommand("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
-} catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	runCommand("diff", ["--brief", "-r", "local", "remote"]);
+} catch (error) {
+	const diffError = error as { stdout?: string | Buffer; stderr?: string | Buffer };
+	const diffOutput = [diffError.stdout, diffError.stderr]
+		.filter((chunk): chunk is string | Buffer => Boolean(chunk))
+		.map((chunk) => chunk.toString())
+		.join("\n");
+
+	if (diffOutput) {
+		console.error(diffOutput);
+	}
+
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"254ff184-8073-4790-a53d-2a1d9bc1f4ad","source":"chat","resourceId":"e74ece27-bbb4-49e5-9bd9-08cf356a17ac","workflowId":"5597f47f-0230-4d1f-b05e-690e26e8cd1c","codeChangeId":"5597f47f-0230-4d1f-b05e-690e26e8cd1c","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/8cece100432beef7707906bc60e92b24?panel_event_id=AwAAAZ8jDYmfajIcAQAAABhBWjhqRFltZkFBRFRpekRtWjh2WndKSS0AAAAkZjE5ZjIzMTMtNWY1MC00NDRmLWJjMzMtN2JjMWE0MDI0MmRkAAArCA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OGNlY2UxMDA0MzJiZWVmNzcwNzkwNmJjNjBlOTJiMjR-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

This change removes shell-interpolated command construction in `scripts/check-deps.ts` to prevent command injection when the dependency argument is provided to the script.

## Changes
- Added explicit validation for the positional dependency argument (`dep`) to only allow expected package-name characters.
- Replaced `execSync` template-string shell commands with `execFileSync` argument arrays for npm/tar/diff execution.
- Replaced shell `mv`/`rm` command usage with Node `fs` APIs (`renameSync`, `rmSync`, `mkdirSync`) to avoid shell parsing of dynamic values.
- Preserved existing package comparison behavior and release-halting error paths.

## Testing
- Attempted repository formatter (`Format`): failed in sandbox because `prettier-plugin-svelte` is unavailable.
- Attempted repository linter (`Lint`): failed in sandbox because Corepack could not download pnpm (no network access).
- Manually reviewed resulting script diff for TypeScript correctness and behavior parity.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e74ece27-bbb4-49e5-9bd9-08cf356a17ac)

Comment @datadog to request changes