### PR TITLE
Harden check-deps command execution

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,5 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +13,21 @@ if (!dep) {
 	process.exit(1);
 }
 
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error(`Error: Invalid dependency "${dep}".`);
+	process.exit(1);
+}
+
+if (!existsSync(`./packages/${dep}`)) {
+	console.error(`Error: Unknown dependency "${dep}".`);
+	process.exit(1);
+}
+
 process.chdir(`./packages/${dep}`);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], { encoding: "utf-8" }).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +36,40 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+execFileSync("npm", ["pack"]);
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`]);
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { force: true, recursive: true });
+mkdirSync("local");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { force: true, recursive: true });
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
+	execFileSync("diff", ["--brief", "-r", "local", "remote"]).toString();
 } catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	const error = e as { stderr?: Buffer | string; stdout?: Buffer | string };
+	const output = [error.stdout, error.stderr]
+		.filter((chunk): chunk is Buffer | string => Boolean(chunk))
+		.map((chunk) => chunk.toString())
+		.join("\n");
+	if (output) {
+		console.error(output);
+	}
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { force: true, recursive: true });
+rmSync("remote", { force: true, recursive: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d3b0a448-7718-4be0-b9df-11fd61536fe7","source":"chat","resourceId":"c334b420-6a61-4eb0-8c8c-b1028e8e1b8e","workflowId":"d5f225de-80f4-476b-8a91-c08bff6fc499","codeChangeId":"d5f225de-80f4-476b-8a91-c08bff6fc499","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/8cece100432beef7707906bc60e92b24?panel_event_id=AwAAAZ8jDYmfajIcAQAAABhBWjhqRFltZkFBRFRpekRtWjh2WndKSS0AAAAkZjE5ZjIzMTMtNWY1MC00NDRmLWJjMzMtN2JjMWE0MDI0MmRkAAArCA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OGNlY2UxMDA0MzJiZWVmNzcwNzkwNmJjNjBlOTJiMjR-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Mitigate a high-severity command injection risk in `scripts/check-deps.ts` by removing shell-interpolated command execution with user-provided dependency input.

## Changes
- Switched from `execSync` shell-string commands to `execFileSync` argument-based execution for npm, tar, and diff operations.
- Added dependency input validation (`^[a-z0-9-]+$`) and an existence check for `./packages/<dep>` before changing directories.
- Replaced shell-based filesystem commands (`mv`, `rm -Rf`, `mkdir`) with Node.js `fs` APIs (`renameSync`, `rmSync`, `mkdirSync`) to avoid shell interpretation entirely.
- Improved diff failure output handling by printing captured stdout/stderr safely from the thrown process error.

## Testing
- Attempted to run:
  - `pnpm prettier --check scripts/check-deps.ts`
  - `pnpm eslint --ext .ts scripts/check-deps.ts`
- Both commands were blocked in this sandbox because Corepack tried to download pnpm from `registry.npmjs.org` (network unavailable in this environment).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c334b420-6a61-4eb0-8c8c-b1028e8e1b8e)

Comment @datadog to request changes