### PR TITLE
Harden check-deps against command injection

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +14,23 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error("Error: Invalid dependency name.");
+	process.exit(1);
+}
+
+const packagePath = resolve("./packages", dep);
+
+if (!existsSync(packagePath)) {
+	console.error(`Error: Package ${dep} not found in ./packages.`);
+	process.exit(1);
+}
+
+process.chdir(packagePath);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], { encoding: "utf-8" }).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +39,39 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+execFileSync("npm", ["pack"], { stdio: "inherit" });
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`], { stdio: "inherit" });
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { force: true, recursive: true });
+mkdirSync("local");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { force: true, recursive: true });
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json", { force: true });
+rmSync("remote/package/package.json", { force: true });
 
 try {
-	execSync("diff --brief -r local remote").toString();
+	execFileSync("diff", ["--brief", "-r", "local", "remote"]).toString();
 } catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	const output = (e as { output?: Array<Buffer | string | null> }).output ?? [];
+	console.error(
+		output
+			.filter((entry): entry is Buffer | string => Boolean(entry))
+			.map((entry) => entry.toString())
+			.join("\n")
+	);
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { force: true, recursive: true });
+rmSync("remote", { force: true, recursive: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"79718fe0-ed9b-4b07-8fc7-58005e41435f","source":"chat","resourceId":"900dd371-af95-433b-96f9-7b6f9221ea60","workflowId":"bdc2750c-d2ac-4054-b2e5-b72d0b278100","codeChangeId":"bdc2750c-d2ac-4054-b2e5-b72d0b278100","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/d364d4ceb21cb093378fc4794b1ae520?panel_event_id=AwAAAZ8jGft0Fc5g1gAAABhBWjhqR2Z0MEFBQmNkZU5YS1VDdElMN20AAAAkZjE5ZjIzMjEtMWFhZC00MmViLTkxYTQtMmViNzI4YjQ4NjYzAABjgw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZDM2NGQ0Y2ViMjFjYjA5MzM3OGZjNDc5NGIxYWU1MjB-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Hardened scripts/check-deps.ts to remove shell-interpolated command execution from untrusted positional input. This closes a potential command injection path when running `npm run check-deps <dep>`.

## Changes
- Added dependency name validation (`^[a-z0-9-]+$`) and package existence checks before changing directories.
- Replaced `execSync` shell-string commands with `execFileSync` argument arrays for npm/tar/diff invocations.
- Replaced shell file operations (`mv`, `rm`, `mkdir`) with Node fs APIs (`renameSync`, `rmSync`, `mkdirSync`).
- Improved diff failure output handling to print buffered stdout/stderr safely.

## Testing
- Attempted `pnpm exec prettier --check scripts/check-deps.ts` (blocked in sandbox: no network access to download pnpm via corepack).
- Attempted `pnpm exec eslint scripts/check-deps.ts` (same environment limitation).
- Verified resulting diff manually for syntax and logic consistency.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/900dd371-af95-433b-96f9-7b6f9221ea60)

Comment @datadog to request changes