### PR TITLE
Harden check-deps against command injection

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +14,22 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+const packageDirs = new Set(
+	readdirSync("./packages", { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+);
+
+if (!packageDirs.has(dep)) {
+	console.error(`Error: Invalid dependency "${dep}".`);
+	process.exit(1);
+}
+
+process.chdir(join("./packages", dep));
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"]).toString().trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +38,37 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+execFileSync("npm", ["pack"]);
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`]);
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+mkdirSync("local");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
-} catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	execFileSync("diff", ["--brief", "-r", "local", "remote"], { stdio: "pipe" });
+} catch (e: unknown) {
+	if (e && typeof e === "object" && "stdout" in e && "stderr" in e) {
+		const stdout = e.stdout ? String(e.stdout) : "";
+		const stderr = e.stderr ? String(e.stderr) : "";
+		console.error([stdout, stderr].filter(Boolean).join("\n"));
+	}
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d5c9050e-f8aa-4b73-956a-a1679c94be5d","source":"chat","resourceId":"b295ccce-3c2a-45b4-9547-3ad5d17fd80a","workflowId":"430961c9-fa9b-4f7c-ad6e-406b8cc6d847","codeChangeId":"430961c9-fa9b-4f7c-ad6e-406b8cc6d847","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f1f32b8506622320a5b9121feec701ee?panel_event_id=AwAAAZ8jDLVPk26W_wAAABhBWjhqRExWUEFBRDlKQlozdWhjT1A4UG0AAAAkZjE5ZjIzMTMtNWY1MC00NDRmLWJjMzMtN2JjMWE0MDI0MmRkAAArIQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjFmMzJiODUwNjYyMjMyMGE1YjkxMjFmZWVjNzAxZWV-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Fixes a high-severity command-injection risk in `scripts/check-deps.ts` where a positional CLI argument was interpolated into shell command strings.

## Changes
- Switched from `execSync` string commands to `execFileSync` argument arrays for external commands.
- Replaced shell utilities (`mv`, `rm`, chained shell commands) with Node.js filesystem APIs (`renameSync`, `rmSync`, `mkdirSync`) where possible.
- Added explicit dependency validation against existing `./packages` directories before changing directories or building package names.
- Kept existing behavior for package comparison and release blocking, including diff output on mismatch.

## Testing
- Attempted to run: `pnpm exec eslint scripts/check-deps.ts`
- Validation could not run in this sandbox because `pnpm` bootstrap requires network access to download tooling.
- Manually reviewed the diff to ensure command execution no longer uses shell-interpolated user input.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b295ccce-3c2a-45b4-9547-3ad5d17fd80a)

Comment @datadog to request changes