### PR TITLE
Harden check-deps command execution

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,5 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +13,23 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+if (!/^[a-z0-9-]+$/i.test(dep)) {
+	console.error(`Error: Invalid dependency name "${dep}".`);
+	process.exit(1);
+}
+
+const packageDir = `./packages/${dep}`;
+
+if (!existsSync(packageDir)) {
+	console.error(`Error: Unknown dependency "${dep}".`);
+	process.exit(1);
+}
+
+process.chdir(packageDir);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], { encoding: "utf-8" }).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +38,44 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+const localTarball = execFileSync("npm", ["pack"], { encoding: "utf-8" }).trim();
+renameSync(localTarball, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+const remoteTarball = execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`], { encoding: "utf-8" }).trim();
+renameSync(remoteTarball, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+const unpackTarball = (tarball: string, destination: string) => {
+	rmSync(destination, { force: true, recursive: true });
+	mkdirSync(destination, { recursive: true });
+	execFileSync("tar", ["-xf", tarball, "-C", destination]);
+};
+
+unpackTarball(`${dep}-local.tgz`, "local");
+unpackTarball(`${dep}-remote.tgz`, "remote");
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync(`local/package/package.json`, { force: true });
+rmSync(`remote/package/package.json`, { force: true });
 
 try {
-	execSync("diff --brief -r local remote").toString();
-} catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	execFileSync("diff", ["--brief", "-r", "local", "remote"]);
+} catch (error) {
+	const commandError = error as { stderr?: Buffer | string; stdout?: Buffer | string };
+	const commandOutput = [commandError.stderr, commandError.stdout]
+		.filter(Boolean)
+		.map((entry) => (typeof entry === "string" ? entry : entry.toString()))
+		.join("\n")
+		.trim();
+
+	if (commandOutput) {
+		console.error(commandOutput);
+	}
+
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync(`local`, { force: true, recursive: true });
+rmSync(`remote`, { force: true, recursive: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5e704dff-55c2-4657-94e8-b0fd9820ce65","source":"chat","resourceId":"5a0caca1-8dab-4b08-a86b-1b3cce1c52c6","workflowId":"f9d9d961-a919-4e78-98c1-527b09c8fcbc","codeChangeId":"f9d9d961-a919-4e78-98c1-527b09c8fcbc","sourceType":"code_security_sast"} -->
## Motivation/Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/f1f32b8506622320a5b9121feec701ee?panel_event_id=AwAAAZ8jDLVPk26W_wAAABhBWjhqRExWUEFBRDlKQlozdWhjT1A4UG0AAAAkZjE5ZjIzMTMtNWY1MC00NDRmLWJjMzMtN2JjMWE0MDI0MmRkAAArIQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZjFmMzJiODUwNjYyMjMyMGE1YjkxMjFmZWVjNzAxZWV-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

The dependency comparison script accepted a positional package name and interpolated it into multiple shell commands. This could allow command injection if an unsafe value is passed to `check-deps`.

## Changes
- Replaced `execSync` shell-string calls with `execFileSync` argument arrays in `scripts/check-deps.ts`.
- Added dependency-name validation (`^[a-z0-9-]+$`) before any filesystem or command execution.
- Added an existence check for `./packages/<dep>` before changing directories.
- Replaced shell file operations (`mv`, `rm`, `mkdir`) with Node.js filesystem APIs (`renameSync`, `rmSync`, `mkdirSync`).
- Kept package consistency behavior intact by still comparing unpacked tarballs via `diff --brief -r`.

## Testing/Validation
- Attempted to run:
  - `pnpm eslint scripts/check-deps.ts`
  - `pnpm prettier --check scripts/check-deps.ts`
- In this sandbox, `pnpm` could not run because Corepack tried to download pnpm from `registry.npmjs.org`, but network access is unavailable.
- Validation should be re-run in CI or a network-enabled dev environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5a0caca1-8dab-4b08-a86b-1b3cce1c52c6)

Comment @datadog to request changes