### PR TITLE
Harden check-deps against command injection

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,5 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +13,18 @@ if (!dep) {
 	process.exit(1);
 }
 
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error(`Error: Invalid dependency "${dep}".`);
+	process.exit(1);
+}
+
 process.chdir(`./packages/${dep}`);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], {
+	encoding: "utf-8",
+}).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +33,33 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+execFileSync("npm", ["pack"]);
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`]);
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("local");
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
+	execFileSync("diff", ["--brief", "-r", "local", "remote"]);
 } catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	const output = (e as { output?: Array<string | Buffer | null | undefined> }).output ?? [];
+	console.error(output.filter(Boolean).map((entry) => entry?.toString()).join("\n"));
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"90725ce4-be3a-41a6-8e90-c41ef4980992","source":"chat","resourceId":"b384ed6b-1b64-42a4-844f-e201db00a863","workflowId":"f7f84375-b365-4643-95d9-ba874bff3076","codeChangeId":"f7f84375-b365-4643-95d9-ba874bff3076","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/5dc27b5d78d4abfb91740130ac8b90c5?panel_event_id=AwAAAZ8jJ-gmMj5RsQAAABhBWjhqSi1nbUFBQ1RfbTRCU0JadXNiaFEAAAAkZjE5ZjIzMmUtZDY5MC00Y2M0LWE5MGQtODE5MjZlMWUxMjQ1AAAJow&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NWRjMjdiNWQ3OGQ0YWJmYjkxNzQwMTMwYWM4YjkwYzV-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Prevent command injection in scripts/check-deps.ts by removing shell-interpolated command execution for user-provided dependency names.

## Changes
- Added strict dependency-name validation (`^[a-z0-9-]+$`) before using the positional CLI argument.
- Replaced shell-based `execSync` invocations with `execFileSync` argument arrays for npm/tar/diff commands.
- Replaced shell file operations (`mv`, `rm`, `mkdir`) with Node fs APIs (`renameSync`, `rmSync`, `mkdirSync`) to avoid shell parsing entirely.
- Kept existing release consistency behavior and error handling flow intact.

## Testing
- Attempted: `pnpm exec prettier --check scripts/check-deps.ts`
- Attempted: `pnpm exec eslint scripts/check-deps.ts`
- Result: blocked in sandbox because corepack tried to download pnpm from registry.npmjs.org (no network access).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b384ed6b-1b64-42a4-844f-e201db00a863)

Comment @datadog to request changes