### PR TITLE
Harden check-deps command execution

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +14,24 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error("Error: Invalid dependency name.");
+	process.exit(1);
+}
+
+const packagePath = join("packages", dep);
+if (!existsSync(join(packagePath, "package.json"))) {
+	console.error(`Error: Could not find dependency package at ${packagePath}.`);
+	process.exit(1);
+}
+
+process.chdir(packagePath);
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], {
+	encoding: "utf-8",
+}).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +40,49 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+const localTarball = execFileSync("npm", ["pack"], {
+	encoding: "utf-8",
+}).trim();
+renameSync(localTarball, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+const remoteTarball = execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`], {
+	encoding: "utf-8",
+}).trim();
+renameSync(remoteTarball, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+mkdirSync("local");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"]);
+
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"]);
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync("local/package/package.json");
+rmSync("remote/package/package.json");
 
 try {
-	execSync("diff --brief -r local remote").toString();
+	execFileSync("diff", ["--brief", "-r", "local", "remote"], {
+		encoding: "utf-8",
+		stdio: "pipe",
+	});
 } catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	const output =
+		typeof e === "object" &&
+		e !== null &&
+		"output" in e &&
+		Array.isArray((e as { output?: unknown }).output)
+			? (e as { output: unknown[] }).output.filter(Boolean).map(String).join("\n")
+			: "";
+	if (output) {
+		console.error(output);
+	}
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dd99ccc1-ada7-4357-929c-c414401de5f1","source":"chat","resourceId":"43823cf9-b35a-475a-bc03-76a9a8c89d8c","workflowId":"1c493aa7-816a-40ff-9c90-ab74a4a2874b","codeChangeId":"1c493aa7-816a-40ff-9c90-ab74a4a2874b","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/02e65031f06dfbc7b467aa66ef5088c7?panel_event_id=AwAAAZ8jGqOviLFEGAAAABhBWjhqR3FPdkFBQ3VDWXVfMEdvVE96TUIAAAAkZjE5ZjIzMjEtMWFhZC00MmViLTkxYTQtMmViNzI4YjQ4NjYzAABjdQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDJlNjUwMzFmMDZkZmJjN2I0NjdhYTY2ZWY1MDg4Yzd-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

Mitigate a high-severity command injection risk in scripts/check-deps.ts by removing shell-interpolated command strings that included user-controlled dependency input.

## Changes
- Switched from execSync string commands to execFileSync argument arrays for npm, tar, and diff invocations.
- Added dependency name validation to allow only expected package-name characters.
- Added package existence validation before chdir to prevent invalid or unexpected paths.
- Replaced shell mv/rm/mkdir usage with Node fs APIs (renameSync, rmSync, mkdirSync) to avoid shell interpretation.
- Preserved existing release guard behavior and error reporting when local/remote package contents differ.

## Testing
- Attempted: pnpm exec eslint scripts/check-deps.ts
- Attempted: pnpm exec prettier --check scripts/check-deps.ts
- Both commands were blocked in this sandbox because pnpm was not locally available and could not be downloaded due restricted network access.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/43823cf9-b35a-475a-bc03-76a9a8c89d8c)

Comment @datadog to request changes