### PR TITLE
Harden check-deps command execution

### DIFF
--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,5 +1,6 @@
-import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 const args = parseArgs({
@@ -13,11 +14,21 @@ if (!dep) {
 	process.exit(1);
 }
 
-process.chdir(`./packages/${dep}`);
+if (!/^[a-z0-9-]+$/.test(dep)) {
+	console.error(`Error: Invalid dependency "${dep}".`);
+	process.exit(1);
+}
+
+try {
+	process.chdir(join(".", "packages", dep));
+} catch {
+	console.error(`Error: Unknown dependency "${dep}".`);
+	process.exit(1);
+}
 
 const localPackageJson = readFileSync(`./package.json`, "utf-8");
 const localVersion = JSON.parse(localPackageJson).version as string;
-const remoteVersion = execSync(`npm view @huggingface/${dep} version`).toString().trim();
+const remoteVersion = execFileSync("npm", ["view", `@huggingface/${dep}`, "version"], { encoding: "utf-8" }).trim();
 
 if (localVersion !== remoteVersion) {
 	console.error(
@@ -26,28 +37,40 @@ if (localVersion !== remoteVersion) {
 	process.exit(1);
 }
 
-execSync(`npm pack`);
-execSync(`mv huggingface-${dep}-${localVersion}.tgz ${dep}-local.tgz`);
+execFileSync("npm", ["pack"], { stdio: "inherit" });
+renameSync(`huggingface-${dep}-${localVersion}.tgz`, `${dep}-local.tgz`);
 
-execSync(`npm pack @huggingface/${dep}@${remoteVersion}`);
-execSync(`mv huggingface-${dep}-${remoteVersion}.tgz ${dep}-remote.tgz`);
+execFileSync("npm", ["pack", `@huggingface/${dep}@${remoteVersion}`], { stdio: "inherit" });
+renameSync(`huggingface-${dep}-${remoteVersion}.tgz`, `${dep}-remote.tgz`);
 
-execSync(`rm -Rf local && mkdir local && tar -xf ${dep}-local.tgz -C local`);
-execSync(`rm -Rf remote && mkdir remote && tar -xf ${dep}-remote.tgz -C remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });
+mkdirSync("local");
+mkdirSync("remote");
+execFileSync("tar", ["-xf", `${dep}-local.tgz`, "-C", "local"], { stdio: "inherit" });
+execFileSync("tar", ["-xf", `${dep}-remote.tgz`, "-C", "remote"], { stdio: "inherit" });
 
 // Remove package.json files because they're modified by npm
-execSync(`rm local/package/package.json`);
-execSync(`rm remote/package/package.json`);
+rmSync(join("local", "package", "package.json"), { force: true });
+rmSync(join("remote", "package", "package.json"), { force: true });
 
 try {
-	execSync("diff --brief -r local remote").toString();
-} catch (e) {
-	console.error(e.output.filter(Boolean).join("\n"));
+	execFileSync("diff", ["--brief", "-r", "local", "remote"], { encoding: "utf-8" });
+} catch (error) {
+	if (typeof error === "object" && error !== null && ("stdout" in error || "stderr" in error)) {
+		const stdout = "stdout" in error ? String((error as { stdout?: unknown }).stdout ?? "").trim() : "";
+		const stderr = "stderr" in error ? String((error as { stderr?: unknown }).stderr ?? "").trim() : "";
+		const output = [stdout, stderr].filter(Boolean).join("\n");
+		if (output) {
+			console.error(output);
+		}
+	}
+
 	console.error(`Error: The local and remote @huggingface/${dep} packages are inconsistent. Release halted.`);
 	process.exit(1);
 }
 
 console.log(`The local and remote @huggingface/${dep} packages are consistent.`);
 
-execSync(`rm -Rf local`);
-execSync(`rm -Rf remote`);
+rmSync("local", { recursive: true, force: true });
+rmSync("remote", { recursive: true, force: true });


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ac6bbc0c-fe62-435c-afb5-6a6b07f32946","source":"chat","resourceId":"3cf8d0b2-969e-4630-bf4b-cb289c98c79e","workflowId":"2bdca754-1877-48cc-aa36-b98996476276","codeChangeId":"2bdca754-1877-48cc-aa36-b98996476276","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/d364d4ceb21cb093378fc4794b1ae520?panel_event_id=AwAAAZ8jGft0Fc5g1gAAABhBWjhqR2Z0MEFBQmNkZU5YS1VDdElMN20AAAAkZjE5ZjIzMjEtMWFhZC00MmViLTkxYTQtMmViNzI4YjQ4NjYzAABjgw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZDM2NGQ0Y2ViMjFjYjA5MzM3OGZjNDc5NGIxYWU1MjB-MTU1Yjc2YTgzMzg2YzU0OWQ0ZDQxYjVhOWU1ZTJhNzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fhuggingface.js%22+%22Potential+command+injection%22)

This change fixes a high-severity command-injection path in `scripts/check-deps.ts` where the positional dependency argument could flow into shell command strings. It reduces risk in release validation workflows by preventing malicious dependency values from being interpreted by a shell.

## Changes
- Replaced shell-string `execSync(...)` calls with `execFileSync(...)` plus explicit argument arrays for `npm`, `tar`, and `diff` invocations.
- Replaced shell file operations (`mv`, `rm`, `mkdir`) with Node filesystem APIs (`renameSync`, `rmSync`, `mkdirSync`).
- Added dependency-name validation (`^[a-z0-9-]+$`) and explicit handling for unknown package directories before `process.chdir`.
- Kept the existing version mismatch and package-content consistency checks intact.

## Testing
- Attempted: `pnpm exec prettier --check scripts/check-deps.ts` (failed in sandbox because Corepack tried to download pnpm and network access is blocked).
- Attempted: `pnpm exec eslint scripts/check-deps.ts` (same network/bootstrap limitation).
- Verified the resulting diff manually to ensure untrusted input is no longer interpolated into shell commands.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3cf8d0b2-969e-4630-bf4b-cb289c98c79e)

Comment @datadog to request changes